### PR TITLE
Avoid declaring doc files as runtime data files

### DIFF
--- a/securemem.cabal
+++ b/securemem.cabal
@@ -14,7 +14,7 @@ Stability:           experimental
 Build-Type:          Simple
 Homepage:            http://github.com/vincenthz/hs-securemem
 Cabal-Version:       >=1.8
-data-files:          README.md
+extra-doc-files:     README.md
 
 Library
   Exposed-modules:   Data.SecureMem


### PR DESCRIPTION
`README.md` is not required as a runtime data file.
