### PR TITLE
Securemem eq fix issue 7

### DIFF
--- a/cbits/utils.c
+++ b/cbits/utils.c
@@ -75,7 +75,7 @@ int compare_eq(uint32_t size, uint8_t *p1, uint8_t *p2)
 	uint32_t i;
 	int acc = 1;
 
-	for (i = 0; i < size / 8; i++)
+	for (i = 0; i < size; i++)
 		acc &= (p1[i] == p2[i]);
 	return acc;
 }

--- a/securemem.cabal
+++ b/securemem.cabal
@@ -30,7 +30,7 @@ Test-suite testsuite
   type:                exitcode-stdio-1.0
   main-is:             TestRunner.hs
   hs-source-dirs:      tests/src
-  build-depends:       base < 5 && >= 4.4
+  build-depends:       base >= 4 && < 5
                      , securemem
                      , tasty                    >= 0.7
                      , tasty-th                 >= 0.1

--- a/securemem.cabal
+++ b/securemem.cabal
@@ -13,7 +13,7 @@ Category:            Data
 Stability:           experimental
 Build-Type:          Simple
 Homepage:            http://github.com/vincenthz/hs-securemem
-Cabal-Version:       >=1.8
+Cabal-Version:       >=1.10
 extra-doc-files:     README.md
 
 Library
@@ -24,6 +24,22 @@ Library
                    , ghc-prim
   C-sources:         cbits/utils.c
   ghc-options:       -Wall -fwarn-tabs
+
+Test-suite testsuite
+  default-language:    Haskell2010
+  type:                exitcode-stdio-1.0
+  main-is:             TestRunner.hs
+  hs-source-dirs:      tests/src
+  build-depends:       base < 5 && >= 4.4
+                     , securemem
+                     , tasty                    >= 0.7
+                     , tasty-th                 >= 0.1
+                     , tasty-hunit              >= 0.4
+                     , tasty-quickcheck         >= 0.3
+                     , QuickCheck               >= 2.4.0.1
+                     , bytestring
+                     , text                     >= 0.11
+                     , byteable                 >= 0.1.1
 
 source-repository head
   type: git

--- a/tests/src/Data/SecureMemTests.hs
+++ b/tests/src/Data/SecureMemTests.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE TemplateHaskell      #-}
+module Data.SecureMemTests
+  (
+    main
+  , defaultTestGroup
+) where
+
+import           Control.Applicative
+import           Data.Byteable
+import           Data.SecureMem
+import           Data.String           (fromString)
+import qualified Data.ByteString       as B
+import qualified Data.Text             as T
+import qualified Data.Text.Encoding    as TE
+import qualified Test.QuickCheck       as QC
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
+import           Test.Tasty.TH
+
+defaultTestGroup :: TestTree
+defaultTestGroup = $(testGroupGenerator)
+
+instance ToSecureMem T.Text where
+        toSecureMem = secureMemFromByteString . TE.encodeUtf8
+
+main :: IO ()
+main = defaultMain defaultTestGroup
+
+case_secureMemEq = do
+    let l = "Joh1R2dYzkRvDkqv3sygm5YyK8Gi4ShZqbhK2gxcs2u" :: B.ByteString
+        r = "Joh1R2dYzkRvDkqv3sygm5YyK8Gi4ShZqbhK2gxcs2U" :: B.ByteString
+    (toSecureMem l /= toSecureMem r) @? "Unequal input should not be equal using SecureMem.Eq"
+
+prop_secureMemEncodeDecodeText = f
+  where
+    f :: T.Text -> Bool
+    f t = t == secureMemToText (toSecureMem t)
+    secureMemToText :: SecureMem -> T.Text
+    secureMemToText = TE.decodeUtf8 . toBytes
+
+prop_secureMemEqText = f
+  where
+    f :: T.Text -> T.Text -> Bool
+    f t1 t2 = let eqt = t1 == t2
+                  eqs = toSecureMem t1 == toSecureMem t2
+              in eqt == eqs
+
+prop_secureMemEqText' = f
+  where
+    f :: T.Text -> T.Text -> Bool
+    f tl tr = let t1 = ("Joh1R2dYzkRvDkqv3sygm5YyK8Gi4ShZqbhK2gxcs2" :: T.Text) `T.append` tl
+                  t2 = ("Joh1R2dYzkRvDkqv3sygm5YyK8Gi4ShZqbhK2gxcs2" :: T.Text) `T.append` tr
+                  eqt = t1 == t2
+                  eqs = toSecureMem t1 == toSecureMem t2
+              in eqt == eqs
+
+prop_secureMemEqByteString = f
+  where
+    f :: B.ByteString -> B.ByteString -> Bool
+    f tl tr = let t1 = ("Joh1R2dYzkRvDkqv3sygm5YyK8Gi4ShZqbhK2gxcs2" :: B.ByteString) `B.append` tl
+                  t2 = ("Joh1R2dYzkRvDkqv3sygm5YyK8Gi4ShZqbhK2gxcs2" :: B.ByteString) `B.append` tr
+                  eqt = t1 == t2
+                  eqs = toSecureMem t1 == toSecureMem t2
+              in eqt == eqs
+
+instance Arbitrary T.Text where
+    arbitrary = fromString <$> (arbitrary :: QC.Gen String)
+
+instance Arbitrary B.ByteString where 
+    arbitrary = B.pack <$> arbitrary
+
+

--- a/tests/src/TestRunner.hs
+++ b/tests/src/TestRunner.hs
@@ -1,0 +1,13 @@
+module Main where
+
+import qualified Data.SecureMemTests
+import           Test.Tasty
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "SecureMem Tests" [
+                    Data.SecureMemTests.defaultTestGroup
+                ]
+


### PR DESCRIPTION
This fixes issue #7 with the tests now passing.

To run the tests:

```
$> cabal install --enable-test --only-dependencies
$> cabal test --show-details=always
```

To be honest I'm not confident that this fixes the problem in the right way even though all the test cases pass now.
